### PR TITLE
Fix for escaping <> & " in post body.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,9 +10,22 @@ var utils = {
    * @see http://stackoverflow.com/a/7918944/842214
    */
   escapeXML : function(str) {
-    return str.replace(/&quot;/g, '"').replace(/&gt;/g, '>').replace(/&lt;/g,
+
+	return str.replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');           
+
+    },
+
+  unEscapeXML : function(str) {
+
+	return str.replace(/&quot;/g, '"').replace(/&gt;/g, '>').replace(/&lt;/g,
         '<').replace(/&amp;/g, '&');
+
   }
+
+
 };
 
 module.exports = utils;


### PR DESCRIPTION
I think the escape function was implemented backwards, decoding entities instead of encoding them.  This causes documents with <> (such as HTML) to be fail to be inserted into Solr.
