### PR TITLE
Added a few options to delete, update Solr docs and other options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,27 @@ solrdoc.setField('field_name4', 'value4', 1 /*boost*/, 'set');
 solr_client.updateDoc(solrdoc, true, function(err) {
   if (err) console.log(err);
 });
+
+Or equivalent:
+
+var solrdoc = new helios.document();
+// update the field_name2
+solrdoc.setField('field_name2', 'value1updated');
+// add the field_name3
+solrdoc.setField('field_name3', 'value3');
+// add the field_name4 with boost=1
+solrdoc.setField('field_name4', 'value4');
+
+// setting the updates and boost
+doc.setFieldUpdate('field_name2', 'set');
+doc.setFieldUpdate('field_name3', 'add');
+doc.setFieldUpdate('field_name4', 'set');
+doc.setFieldBoost('field_name4', 1);
+
+
+solr_client.updateDoc(solrdoc, true, function(err) {
+  if (err) console.log(err);
+});
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -131,7 +131,40 @@ solr_client.addDoc(solrdoc, true, function(err) {
 });
 ```
 
-#### solr_client.deleteDoc
+#### solr_client.updateDoc - For Solr 4.x
+It accepts 3 arguments:  
+- `solrdoc` : an instance of [helios.document](#document)  
+- `commit_flag` : `boolean`  
+- `callback(err)` : a callback which is given an error message upon failure  
+
+NOTES: Use 'set' when you want to update a field value and use 'add' for add a value to multivalue fields. 
+
+```js
+var solrdoc = new helios.document();
+// update the field_name2
+solrdoc.setField('field_name2', 'value1updated', null, 'set');
+// add the field_name3
+solrdoc.setField('field_name3', 'value3', null, 'add');
+// add the field_name4 with boost=1
+solrdoc.setField('field_name4', 'value4', 1 /*boost*/, 'set');
+
+solr_client.updateDoc(solrdoc, true, function(err) {
+  if (err) console.log(err);
+});
+```
+
+```js
+var solrdoc = new helios.document();
+// delete the field_name4
+doc.setFieldDelete('field_name4');
+
+solr_client.updateDoc(solrdoc, true, function(err) {
+  if (err) console.log(err);
+});
+```
+
+
+#### solr_client.deleteDoc - For Solr 4.x
 It accepts 4 arguments:  
 - `id` : The Solr document id. This is defined in the schema.
 - `values` : The list of documents to delete. This could be a string or an array of strings. 
@@ -147,12 +180,12 @@ solr_client.deleteDoc('id', '1' true, function(err) {
 });
 
 // delete the documents with id=2, id=3 and id=4
-solr_client.deleteDoc('id', ['2', '3', '4'] true, function(err) {
+solr_client.deleteDoc('id', ['2', '3', '4'], true, function(err) {
   if (err) console.log(err);
 });
 ```
 
-#### solr_client.deleteDocByQuery
+#### solr_client.deleteDocByQuery - For Solr 4.x
 It accepts 4 arguments:  
 - `query` : The "deleteDocByQuery" uses the Lucene query parser by default. Please refer to Solr documentation for more details.
 - `commit_flag` : `boolean`
@@ -171,7 +204,7 @@ solr_client.deleteDocByQuery('name:Peter', commit, 18, function(err) {
   }
 });
 
-// delete all the documents where name = 'Peter'
+// delete ALL the documents where name = 'Peter' (Be careful when setting maxAffected to 0, you could delete your whole database when query=*:*)
 solr_client.deleteDocByQuery('name:Peter', commit, 0, function(err) {
   if(err) {
     console.log('error: ', err);

--- a/README.md
+++ b/README.md
@@ -131,6 +131,56 @@ solr_client.addDoc(solrdoc, true, function(err) {
 });
 ```
 
+#### solr_client.deleteDoc
+It accepts 4 arguments:  
+- `id` : The Solr document id. This is defined in the schema.
+- `values` : The list of documents to delete. This could be a string or an array of strings. 
+- `commit_flag` : `boolean`
+- `callback(err)` : a callback which is given an error message upon failure  
+
+```js
+var solrdoc = new helios.document();
+
+// delete the document with id=1
+solr_client.deleteDoc('id', '1' true, function(err) {
+  if (err) console.log(err);
+});
+
+// delete the documents with id=2, id=3 and id=4
+solr_client.deleteDoc('id', ['2', '3', '4'] true, function(err) {
+  if (err) console.log(err);
+});
+```
+
+#### solr_client.deleteDocByQuery
+It accepts 4 arguments:  
+- `query` : The "deleteDocByQuery" uses the Lucene query parser by default. Please refer to Solr documentation for more details.
+- `commit_flag` : `boolean`
+- `maxAffected` : Before to delete the docs deleteDocByQuery will check how many docs will be deleted. If this is greather than the the maxAffected value the method will stop. Set this value to 0 if you want to delete all the docs affected by the query.
+- `callback(err)` : a callback which is given an error message upon failure  
+
+```js
+var solrdoc = new helios.document();
+
+// delete all the documents where name = 'Peter' and cancel the delete if there are are more than 18 documents.
+solr_client.deleteDocByQuery('name:Peter', commit, 18, function(err) {
+  if(err) {
+    console.log('error: ', err);
+  } else {
+    console.log('Documents deleted!');
+  }
+});
+
+// delete all the documents where name = 'Peter'
+solr_client.deleteDocByQuery('name:Peter', commit, 0, function(err) {
+  if(err) {
+    console.log('error: ', err);
+  } else {
+    console.log('Documents deleted!');
+  }
+});
+```
+
 <a name="document" />
 ## helios.document
 This class will ease the steps required to make a document to be added to solr.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ doc.setFieldUpdate('field_name3', 'add');
 doc.setFieldUpdate('field_name4', 'set');
 doc.setFieldBoost('field_name4', 1);
 
-
 solr_client.updateDoc(solrdoc, true, function(err) {
   if (err) console.log(err);
 });
@@ -299,6 +298,39 @@ solr_doc.setFieldBoost('field_name', 2.121);
 
 #### getFieldBoosts
 Returns a key-value object of all the fields and their boosts
+
+
+#### getFieldUpdate - For Solr 4.x
+This method returns the update type ('set' or 'add') of `field_name`
+```js
+solr_doc.getFieldUpdate("field_name");
+```
+
+#### setFieldUpdate - For Solr 4.x
+This method sets the update type ('set' or 'add') for field name `field_name`
+```js
+solr_doc.setFieldUpdate('field_name', 'set');
+```
+
+#### getFieldUpdates - For Solr 4.x
+Returns a key-value object of all the fields and their update types
+
+
+#### getFieldDelete - For Solr 4.x
+This method returns the delete setup for a `field_name`
+```js
+solr_doc.getFieldDelete("field_name");
+```
+
+#### setFieldDelete - For Solr 4.x
+This method sets the field name `field_name` to delete from the Solr doc
+```js
+solr_doc.setFieldDelete('field_name');
+```
+
+#### getFieldDeletes - For Solr 4.x
+Returns a key-value object of all the fields to delete from the Solr doc
+
 
 #### clear
 This clears the all the `fields`, `fieldBoosts` as well as the `documentBoost`

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,10 +1,14 @@
 /**
  * @author rishabhmhjn
+ * @modified hguillermo
  */
 
-var helios = require('./'), querystring = require('querystring'), http = require("http"), _ = require("underscore"), logger = require(
-    'nlogger').logger(module);
-;
+var helios        = require('./');
+var querystring   = require('querystring');
+var http          = require("http");
+var _             = require("underscore");
+var logger        = require('nlogger').logger(module);
+
 
 /**
  * @param message
@@ -83,8 +87,7 @@ var solrClient = function(init_opts) {
       req.write(options.data);
     }
     req.end();
-  }
-  ;
+  };
 
   this.select = function(options, callback) {
     var query = '';
@@ -112,8 +115,7 @@ var solrClient = function(init_opts) {
       if (typeof _client['core'] == 'string') {
         _client.path += '/' + _client['core'];
       }
-      _client.path += '/update' + (commit == true ? '?commit=true' : '');
-
+      _client.path += '/update' + (commit == true ? '?commit=true' : '?commit=false');
       _client.data = '<add>' + doc.toXML() + '</add>';
       _client.headers = {
         'Content-Length' : Buffer.byteLength(_client.data),
@@ -125,6 +127,87 @@ var solrClient = function(init_opts) {
       throw new SolrClientException("Bad Solr Document", doc);
     }
   };
+
+  this.updateDoc = function(doc, commit, callback) {
+    //---------------------------------------------------------------------------------------------------------------------
+    // NOTE: Solr has a bug. If there are not fields to update or delete Solr will replace the whole document with the one
+    // we defined in the parameter doc.
+    //---------------------------------------------------------------------------------------------------------------------
+    // check if there is at least one set or add here ==> doc.toXML()
+    if(Object.keys(doc.getFieldUpdates()).length === 0){
+      return callback('There are no fields to update. Please define the fields to update using the setFieldUpdate method.');
+    }
+
+    this.addDoc(doc, commit, callback);
+  };
+
+  this.deleteDoc = function(id, value, commit, callback) {
+    var _client = _.clone(this._client);
+      _client.method = 'POST';
+      if (typeof _client['core'] == 'string') {
+        _client.path += '/' + _client['core'];
+      }
+      _client.path += '/update' + (commit == true ? '?commit=true' : '?commit=false');
+      _client.data = '<delete><'+id+'>' + value + '</'+id+'></delete>';
+      _client.headers = {
+        'Content-Length' : Buffer.byteLength(_client.data),
+        'Content-Type' : 'application/xml'
+      };
+
+      executeQuery(_client, callback);
+  }
+
+  this.deleteDocByQuery = function(query, commit, maxAffected, callback) {
+    // limit the number of documents deleted by the query
+    maxAffected = (typeof maxAffected === "undefined") ? 100 : maxAffected;
+
+    var self = this;
+
+    // before to delete the documents check how many we are going to delete
+    var queryBuilder = new helios.queryBuilder();
+    this.select(queryBuilder.simpleQuery({
+      op : '',
+      df : '',
+      q : query,
+      start: 0,
+      rows: 0
+    }), function(err, res) {
+      if (err) {
+        return callback(err);
+      } else {
+        var totalAffected = -1;
+
+        // find how many documents we are going to delete
+        try{
+          totalAffected = JSON.parse(res).response.numFound;
+        } catch(e){
+          return callback(e);
+        }
+
+        // check if we can run the delete query (maxAffected=0: no limit when deleting documents)
+        if (totalAffected===0){
+          return callback('There are no documents to delete. Please check your delete query ('+query+')');
+        } else if(totalAffected>maxAffected && maxAffected!==0) {
+          return callback('The number of documents to delete ('+totalAffected+') exceeded the maximum permitted ('+maxAffected+')');
+        }
+
+        // delete the documents... 
+        var _client = _.clone(self._client);
+        _client.method = 'POST';
+        if (typeof _client['core'] == 'string') {
+          _client.path += '/' + _client['core'];
+        }
+        _client.path += '/update' + (commit == true ? '?commit=true' : '?commit=false');
+        _client.data = '<delete><query>' + query + '</query></delete>';
+        _client.headers = {
+          'Content-Length' : Buffer.byteLength(_client.data),
+          'Content-Type' : 'application/xml'
+        };
+
+        executeQuery(_client, callback);
+      }
+    });
+  }
 
   // operations based on initialization
   this.setClient(init_opts);

--- a/lib/client.js
+++ b/lib/client.js
@@ -141,20 +141,31 @@ var solrClient = function(init_opts) {
     this.addDoc(doc, commit, callback);
   };
 
-  this.deleteDoc = function(id, value, commit, callback) {
-    var _client = _.clone(this._client);
-      _client.method = 'POST';
-      if (typeof _client['core'] == 'string') {
-        _client.path += '/' + _client['core'];
-      }
-      _client.path += '/update' + (commit == true ? '?commit=true' : '?commit=false');
-      _client.data = '<delete><'+id+'>' + value + '</'+id+'></delete>';
-      _client.headers = {
-        'Content-Length' : Buffer.byteLength(_client.data),
-        'Content-Type' : 'application/xml'
-      };
+  this.deleteDoc = function(id, values, commit, callback) {
+    var data = '';
+    if(Array.isArray(values)){
+      data = '<update>';
+      _.each(values, function(value, i, list){
+        data += '<delete><'+id+'>' + value + '</'+id+'></delete>';
+      });
+      data += '</update>';
+    } else {
+      data = '<delete><'+id+'>' + values + '</'+id+'></delete>';
+    }
 
-      executeQuery(_client, callback);
+    var _client = _.clone(this._client);
+    _client.method = 'POST';
+    if (typeof _client['core'] == 'string') {
+      _client.path += '/' + _client['core'];
+    }
+    _client.path += '/update' + (commit == true ? '?commit=true' : '?commit=false');
+    _client.data = data;
+    _client.headers = {
+      'Content-Length' : Buffer.byteLength(_client.data),
+      'Content-Type' : 'application/xml'
+    };
+
+    executeQuery(_client, callback);
   }
 
   this.deleteDocByQuery = function(query, commit, maxAffected, callback) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -1,5 +1,6 @@
 /**
  * @author rishabhmhjn
+ * @modified hguillermo
  */
 
 var utils = require('./utils');
@@ -8,6 +9,8 @@ var solrDoc = function() {
   var documentBoost = false;
   var fields = {};
   var fieldBoosts = {};
+  var fieldUpdates = {};
+  var fieldDeletes = {};
 
   this.getBoost = function() {
     return documentBoost;
@@ -57,10 +60,14 @@ var solrDoc = function() {
     return (typeof fields[key] != "undefined") ? fields[key] : false;
   };
 
-  this.setField = function(key, value, boost) {
+  this.setField = function(key, value, boost, update) {
     if (typeof boost == 'undefined') {
       boost = false;
     }
+    if (typeof update !== 'undefined') {
+      this.setFieldUpdate(key, update);
+    }
+
     fields[key] = value;
     this.setFieldBoost(key, boost);
     return this;
@@ -85,6 +92,59 @@ var solrDoc = function() {
     return fieldBoosts;
   };
 
+  this.getFieldUpdate = function(key) {
+    return (typeof fieldUpdates[key] != "undefined") ? fieldUpdates[key] : false;
+  };
+
+  this.setFieldUpdate = function(key, update) {
+    var options = {
+      set: true, 
+      add: true
+    };
+    if (typeof update == 'undefined') {
+      update = 'add';
+    }
+    if(!options[update]){
+      // check solr documentation. http://wiki.apache.org/solr/UpdateXmlMessages
+      throw 'Update value not allowed. It must be "set" or "add"'; 
+    }
+
+    fieldUpdates[key] = update;
+    return this;
+  };
+
+  this.getFieldUpdates = function() {
+    return fieldUpdates;
+  };
+
+  this.getFieldDelete = function(key) {
+    return (typeof fieldDeletes[key] != "undefined") ? fieldDeletes[key] : false;
+  };
+
+  /*
+  Based on Solr documentation to delete a field: http://wiki.apache.org/solr/UpdateXmlMessages
+  <add>
+    <doc>
+      <field name="employeeId">05991</field>
+      <field name="skills" update="set" null="true" />
+    </doc>
+  </add>  
+  */
+  this.setFieldDelete = function(key) {
+    if (typeof key == 'undefined') {
+      throw 'Key value can not be undefined.'; 
+    }
+
+    this.setField(key, '');
+    this.setFieldUpdate(key, 'set');
+    fieldDeletes[key] = 'true';
+    return this;
+  };
+
+  this.getFieldDeletes = function() {
+    return fieldDeletes;
+  };
+
   this.clear = function(options) {
     documentBoost = false;
     fieldBoosts = fields = {};
@@ -99,19 +159,28 @@ var solrDoc = function() {
         for ( var oo in fields[o]) {
           data += '<field name="'
               + o
-              + '"'
+              + '"' 
+              + (this.getFieldUpdate(o) ? ' update="'  //new
+                  + this.getFieldUpdate(o) + '"' : '')   //new
+              + (this.getFieldDelete(o) ? ' null="'  //new
+                  + this.getFieldDelete(o) + '"' : '')   //new
               + (this.getFieldBoost(o) ? ' boost="'
-                  + parseFloat(this.getFieldBoost(o)) + '"' : '') + '>';
+                  + parseFloat(this.getFieldBoost(o)) + '"' : '') 
+              + '>';
           data += utils.escapeXML(fields[o][oo]);
           data += '</field>';
         }
       } else {
-        data += '<field name="'
+        data += '<field name="' 
             + o
-            + '"'
+            + '" '
+            + (this.getFieldUpdate(o) ? ' update="'  //new
+                + this.getFieldUpdate(o) + '"' : '')   //new
+            + (this.getFieldDelete(o) ? ' null="'  //new
+                  + this.getFieldDelete(o) + '"' : '')   //new
             + (this.getFieldBoost(o) ? ' boost="'
                 + parseFloat(this.getFieldBoost(o)) + '"' : '') + '>';
-        data += escape(fields[o]);
+        data += utils.escapeXML(fields[o]);
         data += '</field>';
       }
     }


### PR DESCRIPTION
Hi,

I made a lot of changes to use features included in Solr 4.x and up. These changes are:
1. Added  updateDoc method
2. Added a deleteDoc method (a single doc or an array of ids to delete)
3. Added a deleteDocByQuery (remove docs matching the query)
4. Added a method to delete a doc field

In the addDoc readme you are using addField but I think it should be setField?

I tested my code and updated the README. Let me know if you need some other clarification.

Thanks,

Harry
