### PR TITLE
Remove nlogger requires from production libs

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,6 @@ var helios = require('./');
 var querystring = require('querystring');
 var http = require("http");
 var _ = require("underscore");
-var logger = require('nlogger').logger(module);
 
 /**
  * @param message
@@ -42,7 +41,7 @@ var solrClient = function(init_opts) {
 
       /**
        * for proxy based http requests
-       * 
+       *
        * @see http://stackoverflow.com/a/6781592/842214
        */
       if (typeof client.proxy == 'object') {

--- a/lib/queryBuilder.js
+++ b/lib/queryBuilder.js
@@ -2,8 +2,7 @@
  * @author rishabhmhjn
  */
 
-var querystring = require('querystring'), utils = require("./utils"), _ = require('underscore'), logger = require(
-    'nlogger').logger(module);
+var querystring = require('querystring'), utils = require("./utils"), _ = require('underscore');
 
 /**
  * @returns {queryBuilder}
@@ -12,7 +11,7 @@ function queryBuilder() {
 
   /**
    * Default query parameters
-   * 
+   *
    * @type object
    */
   var query = {
@@ -26,7 +25,7 @@ function queryBuilder() {
 
   /**
    * Get the query string
-   * 
+   *
    * @param void
    * @returns string
    */


### PR DESCRIPTION
Since nlogger is listed as a devDependency, it would not be installed using `npm install --production`, which is an expected install situation for production code. 

Since nlogger did not appear to be in active use in the libs, I simply removed the requires. It remains as a devDependency, and in the tests, which would require a dev install to run.
